### PR TITLE
Allow removing payment methods from the list in PaymentMethod.vue

### DIFF
--- a/resources/js/PartialPages/PaymentMethod.vue
+++ b/resources/js/PartialPages/PaymentMethod.vue
@@ -81,6 +81,7 @@
                                 type="button"
                                 typeButton="red"
                                 class="relative top-1.5 self-end"
+                                @click="_removePaymentMethod(value)"
                             ></Button>
                         </td>
                     </tr>
@@ -167,6 +168,12 @@ function _addPaymentMethod() {
     });
     list_values.payment_method_insert = null;
     list_values.value = null;
+}
+
+function _removePaymentMethod(paymentMethodToRemove) {
+    list_all.value = list_all.value.filter(
+        (paymentMethod) => paymentMethod !== paymentMethodToRemove
+    );
 }
 
 function _loadData() {


### PR DESCRIPTION
### Motivation
- Restore delete functionality for payment methods by wiring the table button to an action that removes the selected entry from the local list, since the button previously had no click handler.

### Description
- Add `@click="_removePaymentMethod(value)"` to the delete `Button` and implement `function _removePaymentMethod(paymentMethodToRemove)` which updates `list_all.value` by filtering out the selected item.

### Testing
- Ran the frontend test/lint commands (`npm run test:unit` and `npm run lint`) against the codebase and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc4343f6808322b1179f9204153c5d)